### PR TITLE
Removed the auf module. The aufs module is deprecated as of Proxmox V…

### DIFF
--- a/create_container.sh
+++ b/create_container.sh
@@ -68,7 +68,6 @@ pushd $TEMP_DIR >/dev/null
 wget -qL https://github.com/chpego/proxmox_unifi_network_controler_lxc/raw/main/setup.sh
 
 # Detect modules and automatically load at boot
-load_module aufs
 load_module overlay
 
 # Select storage location

--- a/setup.sh
+++ b/setup.sh
@@ -32,7 +32,7 @@ apt-get autoremove >/dev/null
 
 # Update container OS
 msg "Updating container OS..."
-apt-get update >/dev/null
+apt-get  --allow-releaseinfo-change update >/dev/null
 apt-get install ca-certificates wget -y >/dev/null
 
 # Installing Unifi


### PR DESCRIPTION
…E 7.0. See this https://quibtech.com/p/run-docker-containers-in-proxmox-lxc/

Also Added --allow-releaseinfo-change option to allow apt-get to update even though the repositories have changed their 'Suite' value.

Fixes #1 and  #2 