### PR TITLE
Removed the auf module. The aufs module is deprecated as of Proxmox V…

### DIFF
--- a/create_container.sh
+++ b/create_container.sh
@@ -68,7 +68,6 @@ pushd $TEMP_DIR >/dev/null
 wget -qL https://github.com/chpego/proxmox_unifi_network_controler_lxc/raw/main/setup.sh
 
 # Detect modules and automatically load at boot
-load_module aufs
 load_module overlay
 
 # Select storage location


### PR DESCRIPTION
…E 7.0. See this https://quibtech.com/p/run-docker-containers-in-proxmox-lxc/

Fixes #2 